### PR TITLE
Move the `exp_ps` function under HAVE_NEON

### DIFF
--- a/download_mnist.sh
+++ b/download_mnist.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-# Download and prepare the MNIST dataset for QGT-MNIST
+#!/usr/bin/env bash
+# Download and prepare the MNIST dataset for SIMPLE-MNIST
 # This script downloads the MNIST dataset from Google Cloud Storage,
 # which is a reliable mirror of the original dataset.
 
@@ -27,7 +27,7 @@ files=(
 for file in "${files[@]}"; do
   echo -e "Downloading ${file}..."
   wget -q --show-progress https://storage.googleapis.com/cvdf-datasets/mnist/${file}
-  
+
   # Check if download was successful
   if [ $? -ne 0 ]; then
     echo -e "${RED}Error: Failed to download ${file}${NC}"
@@ -81,9 +81,9 @@ echo "- ${test_images_count} test images (28x28 pixels)"
 
 echo -e "\n${GREEN}MNIST dataset has been downloaded and prepared successfully${NC}"
 echo -e "Path to MNIST data: $(pwd)"
-echo -e "You can use this path as an argument to qgt_mnist:"
-echo -e "${BLUE}./qgt_mnist $(pwd)${NC}"
+echo -e "You can use this path as an argument to simple_mnist:"
+echo -e "${BLUE}./simple_mnist $(pwd)${NC}"
 echo -e "Or if you're in the build directory:"
-echo -e "${BLUE}./qgt_mnist ../mnist_data${NC}"
+echo -e "${BLUE}./simple_mnist ./mnist_data${NC}"
 
 exit 0

--- a/src/neon_ops.c
+++ b/src/neon_ops.c
@@ -29,7 +29,7 @@ bool neon_available(void) {
 static void __attribute__((unused)) fallback_matrix_multiply(const float *A, const float *B, float *C, int M, int N, int K) {
     // Initialize C to zeros
     memset(C, 0, M * N * sizeof(float));
-    
+
     // Compute C = A * B
     for (int i = 0; i < M; i++) {
         for (int k = 0; k < K; k++) {
@@ -44,20 +44,20 @@ void neon_matrix_multiply(const float *A, const float *B, float *C, int M, int N
 #if HAVE_NEON
     // Initialize C to zeros
     memset(C, 0, M * N * sizeof(float));
-    
+
     // Process 4 rows of A and 4 columns of B at a time when possible
     for (int i = 0; i < M; i++) {
         for (int j = 0; j < N; j += 4) {
             if (j + 4 <= N) {
                 // 4 output values at a time
                 float32x4_t c_val = vdupq_n_f32(0.0f);
-                
+
                 for (int k = 0; k < K; k++) {
                     float32x4_t b_val = vld1q_f32(&B[k * N + j]);
                     float32x4_t a_val = vdupq_n_f32(A[i * K + k]);
                     c_val = vmlaq_f32(c_val, a_val, b_val);
                 }
-                
+
                 vst1q_f32(&C[i * N + j], c_val);
             } else {
                 // Handle remaining columns (less than 4)
@@ -82,23 +82,23 @@ void neon_matrix_vector_multiply(const float *A, const float *x, float *y, int M
     for (int i = 0; i < M; i++) {
         float32x4_t sum_vec = vdupq_n_f32(0.0f);
         int j = 0;
-        
+
         // Process 4 elements at a time
         for (; j <= N - 4; j += 4) {
             float32x4_t a_vec = vld1q_f32(&A[i * N + j]);
             float32x4_t x_vec = vld1q_f32(&x[j]);
             sum_vec = vmlaq_f32(sum_vec, a_vec, x_vec);
         }
-        
+
         // Extract the sum
         float sum = vgetq_lane_f32(sum_vec, 0) + vgetq_lane_f32(sum_vec, 1) +
                     vgetq_lane_f32(sum_vec, 2) + vgetq_lane_f32(sum_vec, 3);
-        
+
         // Handle remaining elements
         for (; j < N; j++) {
             sum += A[i * N + j] * x[j];
         }
-        
+
         y[i] = sum;
     }
 #else
@@ -117,14 +117,14 @@ void neon_relu(const float *x, float *y, int n) {
 #if HAVE_NEON
     const float32x4_t zero = vdupq_n_f32(0.0f);
     int i = 0;
-    
+
     // Process 4 elements at a time
     for (; i <= n - 4; i += 4) {
         float32x4_t x_vec = vld1q_f32(&x[i]);
         float32x4_t y_vec = vmaxq_f32(x_vec, zero);
         vst1q_f32(&y[i], y_vec);
     }
-    
+
     // Handle remaining elements
     for (; i < n; i++) {
         y[i] = fmaxf(x[i], 0.0f);
@@ -140,7 +140,7 @@ void neon_relu(const float *x, float *y, int n) {
 void neon_elementwise_multiply(const float *x, const float *y, float *z, int n) {
 #if HAVE_NEON
     int i = 0;
-    
+
     // Process 4 elements at a time
     for (; i <= n - 4; i += 4) {
         float32x4_t x_vec = vld1q_f32(&x[i]);
@@ -148,7 +148,7 @@ void neon_elementwise_multiply(const float *x, const float *y, float *z, int n) 
         float32x4_t z_vec = vmulq_f32(x_vec, y_vec);
         vst1q_f32(&z[i], z_vec);
     }
-    
+
     // Handle remaining elements
     for (; i < n; i++) {
         z[i] = x[i] * y[i];
@@ -161,9 +161,9 @@ void neon_elementwise_multiply(const float *x, const float *y, float *z, int n) 
 #endif
 }
 
+#if HAVE_NEON
 // Fast approximation of exp function using ARM Neon
 static float32x4_t exp_ps(float32x4_t x) {
-#if HAVE_NEON
     // Better exp approximation using minimax polynomial
     const float32x4_t LOG2EF = vdupq_n_f32(1.442695040f);
     const float32x4_t C1 = vdupq_n_f32(0.693147182f);
@@ -199,25 +199,22 @@ static float32x4_t exp_ps(float32x4_t x) {
     const int32x4_t pow2n = vshlq_n_s32(vcvtq_s32_f32(n), 23);
     const float32x4_t pow2 = vreinterpretq_f32_s32(vaddq_s32(pow2n, vdupq_n_s32(0x3f800000)));
     result = vmulq_f32(result, pow2);
-    
+
     return result;
-#else
-    // This should never be called in non-NEON code paths
-    return vdupq_n_f32(0.0f);
-#endif
 }
+#endif
 
 void neon_exp(const float *x, float *y, int n) {
 #if HAVE_NEON
     int i = 0;
-    
+
     // Process 4 elements at a time
     for (; i <= n - 4; i += 4) {
         float32x4_t x_vec = vld1q_f32(&x[i]);
         float32x4_t y_vec = exp_ps(x_vec);
         vst1q_f32(&y[i], y_vec);
     }
-    
+
     // Handle remaining elements with standard exp
     for (; i < n; i++) {
         y[i] = expf(x[i]);
@@ -239,37 +236,37 @@ void neon_softmax(const float *x, float *y, int n) {
             max_val = x[i];
         }
     }
-    
+
     // Compute exp(x - max) and sum
     float sum = 0.0f;
     float *exp_values = (float *)malloc(n * sizeof(float));
-    
+
     for (int i = 0; i < n; i++) {
         exp_values[i] = x[i] - max_val;
     }
-    
+
     neon_exp(exp_values, exp_values, n);
-    
+
     for (int i = 0; i < n; i++) {
         sum += exp_values[i];
     }
-    
+
     // Normalize to get probabilities
     float32x4_t sum_vec = vdupq_n_f32(sum);
     int i = 0;
-    
+
     // Process 4 elements at a time
     for (; i <= n - 4; i += 4) {
         float32x4_t exp_vec = vld1q_f32(&exp_values[i]);
         float32x4_t y_vec = vdivq_f32(exp_vec, sum_vec);
         vst1q_f32(&y[i], y_vec);
     }
-    
+
     // Handle remaining elements
     for (; i < n; i++) {
         y[i] = exp_values[i] / sum;
     }
-    
+
     free(exp_values);
 #else
     // Fallback implementation
@@ -280,14 +277,14 @@ void neon_softmax(const float *x, float *y, int n) {
             max_val = x[i];
         }
     }
-    
+
     // Compute exp(x - max) and sum
     float sum = 0.0f;
     for (int i = 0; i < n; i++) {
         y[i] = expf(x[i] - max_val);
         sum += y[i];
     }
-    
+
     // Normalize to get probabilities
     for (int i = 0; i < n; i++) {
         y[i] /= sum;


### PR DESCRIPTION
Move the `exp_ps` function under HAVE_NEON so that non-NEON platforms can compile this program. 

(Since type `float32x4_t` is in the header file `<arm_neon.h>`)